### PR TITLE
#3 - Base test case for support for collections and maps

### DIFF
--- a/src/test/groovy/nebula/plugin/override/BaseNebulaOverridePluginIntegrationTest.groovy
+++ b/src/test/groovy/nebula/plugin/override/BaseNebulaOverridePluginIntegrationTest.groovy
@@ -1,0 +1,12 @@
+package nebula.plugin.override
+
+import nebula.test.IntegrationSpec
+
+abstract class BaseNebulaOverridePluginIntegrationTest extends IntegrationSpec {
+
+    def setup() {
+        buildFile << """
+        apply plugin: nebula.plugin.override.NebulaOverridePlugin
+        """
+    }
+}

--- a/src/test/groovy/nebula/plugin/override/ComplexTypeExtension.groovy
+++ b/src/test/groovy/nebula/plugin/override/ComplexTypeExtension.groovy
@@ -1,0 +1,28 @@
+package nebula.plugin.override
+
+class ComplexTypeExtension {
+
+    List nullUntypedStringList
+    List<String> nullStringList
+    List<Integer> ullIntegerList
+    Set nullUntypedStringSet
+    Set<String> nullStringSet
+    Set<Integer> nullIntegerSet
+    Map nullUntypedStringToStringMap    //Q: Do we want to support other untyped maps?
+    Map<String, String> nullStringToStringMap
+    Map<String, Integer> nullStringToIntegerMap
+    Map<Integer, Integer> nullIntegerToIntegerMap
+    Map<Integer, String> nullIntegerToStringMap
+
+    List untypedStringList = ['str']
+    List<String> stringList = ['str']
+    List<Integer> integerList = [1]
+    Set untypedStringSet = ['str']
+    Set<String> stringSet = ['str']
+    Set<Integer> integerSet = [1]
+    Map untypedStringToStringMap = ['str': 'str2']    //Q: Do we want to support other untyped maps?
+    Map<String, String> stringToStringMap = ['str': 'str2']
+    Map<String, Integer> stringToIntegerMap = ['str': 1]
+    Map<Integer, Integer> integerToIntegerMap = [(0): 1]
+    Map<Integer, String> integerToStringMap = [(0): 'str2']
+}

--- a/src/test/groovy/nebula/plugin/override/ComplexTypePropertyIntegrationTest.groovy
+++ b/src/test/groovy/nebula/plugin/override/ComplexTypePropertyIntegrationTest.groovy
@@ -1,0 +1,39 @@
+package nebula.plugin.override
+
+import nebula.test.functional.ExecutionResult
+import spock.lang.Ignore
+import spock.lang.Issue
+import spock.lang.Unroll
+
+@Ignore
+@Issue("https://github.com/nebula-plugins/gradle-override-plugin/issues/3")
+class ComplexTypePropertyIntegrationTest extends BaseNebulaOverridePluginIntegrationTest {
+
+    @Unroll("'#commandLineParameter' should be converted to '#expectedValue'")
+    def "Should allow to override List property"() {
+        given:
+            buildFile << """
+                class MyExtension {
+                    List myList
+                }
+
+                extensions.create('example', MyExtension)
+
+                assert example.myList == null
+
+                task checkOverridenProperties {
+                    doLast {
+                        assert example.myList == $expectedValue
+                    }
+                }
+                """
+        when:
+            ExecutionResult executionResult = runTasksSuccessfully('checkOverridenProperties', "-Doverride.example.myList=$commandLineParameter")
+        then:
+            executionResult.standardOutput.contains(':checkOverridenProperties')
+        where:
+            commandLineParameter || expectedValue
+            'foo,bar'            || "['foo', 'bar']"
+            '[1,2]'              || "[1, 2]"
+    }
+}

--- a/src/test/groovy/nebula/plugin/override/NebulaOverridePluginIntegrationTest.groovy
+++ b/src/test/groovy/nebula/plugin/override/NebulaOverridePluginIntegrationTest.groovy
@@ -1,17 +1,10 @@
 package nebula.plugin.override
 
-import nebula.test.IntegrationSpec
 import nebula.test.functional.ExecutionResult
 import org.apache.commons.lang.exception.ExceptionUtils
-import spock.lang.Ignore
 import spock.lang.Issue
 
-class NebulaOverridePluginIntegrationTest extends IntegrationSpec {
-    def setup() {
-        buildFile << """
-        apply plugin: nebula.plugin.override.NebulaOverridePlugin
-        """
-    }
+class NebulaOverridePluginIntegrationTest extends BaseNebulaOverridePluginIntegrationTest {
 
     def "Fails build if property to be overriden cannot be resolved"() {
         setup:

--- a/src/test/groovy/nebula/plugin/override/converter/ComplexTypeConvertionTest.groovy
+++ b/src/test/groovy/nebula/plugin/override/converter/ComplexTypeConvertionTest.groovy
@@ -1,0 +1,74 @@
+package nebula.plugin.override.converter
+
+import nebula.plugin.override.ComplexTypeExtension
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class ComplexTypeConvertionTest extends Specification {
+
+    ComplexTypeExtension ext = new ComplexTypeExtension()
+
+    @Unroll
+    def "Can convert '#valueString' for #propertyName"() {
+        expect:
+            //TODO
+
+        where:
+            valueString           | propertyName                   || typedValue
+            '[foo,bar]'           | 'nullUntypedStringList'        || ['foo', 'bar']
+            'foo,bar'             | 'nullUntypedStringList'        || ['foo', 'bar']
+            '[foo,bar]'           | 'nullStringList'               || ['foo', 'bar']
+            'foo,bar'             | 'nullStringList'               || ['foo', 'bar']
+            '[]'                  | 'nullStringList'               || []
+            'null'                | 'nullStringList'               || ['null']
+            '(null)'              | 'nullStringList'               || null
+            '[1,2]'               | 'nullIntegerList'              || [1, 2]
+            '1,2'                 | 'nullIntegerList'              || [1, 2]
+            'null'                | 'nullIntegerList'              || null
+            '(null)'              | 'nullIntegerList'              || null
+            '[foo,bar]'           | 'nullUntypedStringSet'         || ['foo', 'bar'] as Set
+            'foo,bar'             | 'nullUntypedStringSet'         || ['foo', 'bar'] as Set
+            '[foo,bar]'           | 'nullStringSet'                || ['foo', 'bar'] as Set
+            'foo,bar'             | 'nullStringSet'                || ['foo', 'bar'] as Set
+            '[1,2]'               | 'nullIntegerSet'               || [1, 2] as Set
+            '1,2'                 | 'nullIntegerSet'               || [1, 2] as Set
+            '[foo:bar,foo2:bar2]' | 'nullUntypedStringToStringMap' || [foo: 'bar', foo2: 'bar2']
+            'foo:bar,foo2:bar2'   | 'nullUntypedStringToStringMap' || [foo: 'bar', foo2: 'bar2']
+            '[foo:bar,foo2:bar2]' | 'nullStringToStringMap'        || [foo: 'bar', foo2: 'bar2']
+            'foo:bar,foo2:bar2'   | 'nullStringToStringMap'        || [foo: 'bar', foo2: 'bar2']
+            '[foo:1,foo2:2]'      | 'nullStringToIntegerMap'       || [foo: 1, foo2: 2]
+            'foo:1,foo2:2'        | 'nullStringToIntegerMap'       || [foo: 1, foo2: 2]
+            '[1:10,2:20]'         | 'nullIntegerToIntegerMap'      || [(1): 10, (2): 20]
+            '1:10,2:20'           | 'nullIntegerToIntegerMap'      || [(1): 10, (2): 20]
+            '[:]'                 | 'nullIntegerToIntegerMap'      || [:]
+
+            '[foo,bar]'           | 'untypedStringList'            || ['foo', 'bar']
+            'foo,bar'             | 'untypedStringList'            || ['foo', 'bar']
+            '[foo,bar]'           | 'stringList'                   || ['foo', 'bar']
+            'foo,bar'             | 'stringList'                   || ['foo', 'bar']
+            '[]'                  | 'stringList'                   || []
+            'null'                | 'stringList'                   || ['null']
+            '(null)'              | 'stringList'                   || null
+            '[1,2]'               | 'integerList'                  || [1, 2]
+            '1,2'                 | 'integerList'                  || [1, 2]
+            'null'                | 'integerList'                  || null
+            '(null)'              | 'integerList'                  || null
+            '[foo,bar]'           | 'untypedStringSet'             || ['foo', 'bar'] as Set
+            'foo,bar'             | 'untypedStringSet'             || ['foo', 'bar'] as Set
+            '[foo,bar]'           | 'stringSet'                    || ['foo', 'bar'] as Set
+            'foo,bar'             | 'stringSet'                    || ['foo', 'bar'] as Set
+            '[1,2]'               | 'integerSet'                   || [1, 2] as Set
+            '1,2'                 | 'integerSet'                   || [1, 2] as Set
+            '[foo:bar,foo2:bar2]' | 'untypedStringToStringMap'     || [foo: 'bar', foo2: 'bar2']
+            'foo:bar,foo2:bar2'   | 'untypedStringToStringMap'     || [foo: 'bar', foo2: 'bar2']
+            'null'                | 'untypedStringToStringMap'     || null
+            '[foo:bar,foo2:bar2]' | 'stringToStringMap'            || [foo: 'bar', foo2: 'bar2']
+            'foo:bar,foo2:bar2'   | 'stringToStringMap'            || [foo: 'bar', foo2: 'bar2']
+            '[foo:1,foo2:2]'      | 'stringToIntegerMap'           || [foo: 1, foo2: 2]
+            'foo:1,foo2:2'        | 'stringToIntegerMap'           || [foo: 1, foo2: 2]
+            '[1:10,2:20]'         | 'integerToIntegerMap'          || [(1): 10, (2): 20]
+            '1:10,2:20'           | 'integerToIntegerMap'          || [(1): 10, (2): 20]
+            '[:]'                 | 'integerToIntegerMap'          || [:]
+            'null'                | 'integerToIntegerMap'          || null
+    }
+}


### PR DESCRIPTION
Base test cases for #3 - Ability to override List/Set/Map property.

As there are many cases functional testing all of them with nebula-test plugin would be an overkill. I left 2 simple cases and moved other to unit/integration tests. The implementation would probably require to extract a mechanism from `DotNotationWalkerOverrideStrategy` to determine a field type (also a generic type for collections - like `foo.class.declaredFields[0].getGenericType()`) and leave only base types for `ApacheCommonsTypeConverter`. Therefore I left test in a very generic form.

I am not also sure about the name. ComplexType can suggest that complex/custom type can be passed. Collections and Maps is an alternative.

Probably not all test cases should be supported - to make the implementation easier. Also there are for sure cases I missed.

Regarding `def` as extension is exposed API I would consider the lack of support for fields defined as `def` or use specific default behavior which to cover only base cases (the easier way).

If you decide to keep so many test cases the duplication in `where:` part could be eliminated with some Groovy tricks on `propertyName` column.
