### PR TITLE
No exceptions on unfound properties

### DIFF
--- a/src/main/groovy/nebula/plugin/override/NebulaOverridePlugin.groovy
+++ b/src/main/groovy/nebula/plugin/override/NebulaOverridePlugin.groovy
@@ -1,6 +1,5 @@
 package nebula.plugin.override
 
-import com.sun.org.apache.bcel.internal.classfile.Unknown
 import nebula.plugin.override.reader.AggregateOverrideReader
 import nebula.plugin.override.reader.OverrideReader
 import org.gradle.api.Plugin

--- a/src/test/groovy/nebula/plugin/override/NebulaOverridePluginIntegrationTest.groovy
+++ b/src/test/groovy/nebula/plugin/override/NebulaOverridePluginIntegrationTest.groovy
@@ -2,8 +2,6 @@ package nebula.plugin.override
 
 import nebula.test.IntegrationSpec
 import nebula.test.functional.ExecutionResult
-import org.apache.commons.lang.exception.ExceptionUtils
-import spock.lang.Ignore
 import spock.lang.Issue
 
 class NebulaOverridePluginIntegrationTest extends IntegrationSpec {


### PR DESCRIPTION
Fix #8, in multi-module projects throwing an exception makes this plugin unusable.
